### PR TITLE
Добавлена поддержка методов для импорта задач, комментариев и вложения

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionMajor>4</VersionMajor>
+    <VersionMajor>5</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <BuildNumber>$(BuildNumber)</BuildNumber>
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateCommentRequest.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateCommentRequest.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,13 +16,28 @@ using System.Collections.Generic;
 
 namespace Mindbox.YandexTracker;
 
-public sealed record CreateCommentRequest
+/// <summary>
+/// Запрос на создание комментария к задаче.
+/// </summary>
+public record CreateCommentRequest
 {
+	/// <summary>
+	/// Текст комментария.
+	/// </summary>
 	public required string Text { get; init; }
 
+	/// <summary>
+	/// Список идентификаторов вложений, прикрепленных к комментарию.
+	/// </summary>
 	public IReadOnlyCollection<string>? AttachmentIds { get; init; }
 
+	/// <summary>
+	/// Идентификаторы или логины призванных пользователей.
+	/// </summary>
 	public IReadOnlyCollection<string>? Summonees { get; init; }
 
+	/// <summary>
+	/// Список рассылок, призванных в комментарии.
+	/// </summary>
 	public IReadOnlyCollection<string>? MaillistSummonees { get; init; }
 }

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateIssueRequest.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateIssueRequest.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -54,4 +54,9 @@ public sealed record CreateIssueRequest : CustomFieldsRequest
 	public string? Assignee { get; init; }
 
 	public IReadOnlyCollection<string>? Tags { get; init; }
+
+	/// <summary>
+	/// Идентификатор проекта, к которому относится задача.
+	/// </summary>
+	public int? Project { get; init; }
 }

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateIssueRequest.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateIssueRequest.cs
@@ -17,41 +17,60 @@ using System.Collections.Generic;
 
 namespace Mindbox.YandexTracker;
 
-public sealed record CreateIssueRequest : CustomFieldsRequest
+public record CreateIssueRequest : CustomFieldsRequest
 {
-	public required string Summary { get; init; }
-
+	/// <summary>
+	/// Ключ очереди.
+	/// </summary>
 	public required string Queue { get; init; }
 
-	public IReadOnlyCollection<string>? Followers { get; init; }
+	/// <summary>
+	/// Название задачи.
+	/// </summary>
+	public required string Summary { get; init; }
 
-	public string? Type { get; init; }
+	/// <summary>
+	/// Идентификатор типа задачи. Тип задачи должен присутствовать в очереди.
+	/// </summary>
+	/// <remarks>
+	/// Если тип не указан, то используется тип задачи, который выбран для очереди по умолчанию.
+	/// </remarks>
+	public long? Type { get; init; }
 
+	/// <summary>
+	/// Дедлайн.
+	/// </summary>
+	public DateOnly? DueDate { get; init; }
+
+	/// <summary>
+	/// Описание задачи.
+	/// </summary>
 	public string? Description { get; init; }
+
+	/// <summary>
+	/// Дата начала.
+	/// </summary>
+	public DateOnly? Start { get; init; }
+
+	/// <summary>
+	/// Дата окончания.
+	/// </summary>
+	public DateOnly? End { get; init; }
 
 	public string? Parent { get; init; }
 
-	public DateOnly? Start { get; init; }
-	public DateOnly? End { get; init; }
-	public DateOnly? DueDate { get; init; }
-
-	public string? Author { get; init; }
-
-	public string? QaEngineer { get; init; }
-
-	public IReadOnlyCollection<string>? Access { get; init; }
-
-	public int? PossibleSpam { get; init; }
-
-	public string? Unique { get; init; }
-
-	public IReadOnlyCollection<string>? AttachmentIds { get; init; }
-
-	public IReadOnlyCollection<string>? Sprint { get; init; }
-
-	public Priority? Priority { get; init; }
-
+	/// <summary>
+	/// Логин или идентификатор исполнителя.
+	/// </summary>
 	public string? Assignee { get; init; }
+
+	/// <summary>
+	/// Идентификатор приоритета.
+	/// </summary>
+	/// <remarks>
+	///Если приоритет не указан, то используется приоритет, который выбран для очереди по умолчанию.
+	/// </remarks>
+	public Priority? Priority { get; init; }
 
 	public IReadOnlyCollection<string>? Tags { get; init; }
 
@@ -59,4 +78,38 @@ public sealed record CreateIssueRequest : CustomFieldsRequest
 	/// Идентификатор проекта, к которому относится задача.
 	/// </summary>
 	public int? Project { get; init; }
+
+	public IReadOnlyCollection<string>? Sprint { get; init; }
+
+	/// <summary>
+	/// Поле с уникальным значением, позволяющее предотвратить создание дубликатов задач.
+	/// </summary>
+	/// <remarks>
+	/// При повторной попытке создать задачу с тем же значением данного параметра дубликат создан не будет,
+	/// а ответ будет содержать ошибку с кодом 409.
+	/// </remarks>
+	public string? Unique { get; init; }
+
+	/// <summary>
+	/// Значение параметра Story Points.
+	/// </summary>
+	public double? StoryPoints { get; init; }
+
+	public string? Author { get; init; }
+
+	public string? QaEngineer { get; init; }
+
+	/// <summary>
+	/// Массив с идентификаторами или логинами пользователей, перечисленных в поле Доступ.
+	/// </summary>
+	public IReadOnlyCollection<string>? Access { get; init; }
+
+	public int? PossibleSpam { get; init; }
+
+	public IReadOnlyCollection<string>? AttachmentIds { get; init; }
+
+	/// <summary>
+	/// Идентификаторы или логины наблюдателей задачи.
+	/// </summary>
+	public IReadOnlyCollection<string>? Followers { get; init; }
 }

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateIssueRequest.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/CreateIssueRequest.cs
@@ -17,6 +17,9 @@ using System.Collections.Generic;
 
 namespace Mindbox.YandexTracker;
 
+/// <summary>
+/// Запрос на создание новой задачи.
+/// </summary>
 public record CreateIssueRequest : CustomFieldsRequest
 {
 	/// <summary>

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/ImportCommentRequest.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/ImportCommentRequest.cs
@@ -1,3 +1,17 @@
+// Copyright 2024 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 
 namespace Mindbox.YandexTracker;

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/ImportCommentRequest.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/ImportCommentRequest.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Mindbox.YandexTracker;
+
+/// <summary>
+/// Запрос на импорт комментария к задаче.
+/// </summary>
+/// <remarks>
+/// Должен вызываться только администратором системы.
+/// В отличие от <see cref="CreateCommentRequest"/>, позволяет указать дату создания комментария,
+/// а также в качестве создателя задачи указать любого пользователя.
+/// </remarks>
+public record ImportCommentRequest
+{
+	/// <summary>
+	/// Текст комментария.
+	/// </summary>
+	public required string Text { get; init; }
+
+	/// <summary>
+	/// Автор комментария.
+	/// </summary>
+	public required string CreatedBy { get; init; }
+
+	/// <summary>
+	/// Дата и время создания комментария.
+	/// </summary>
+	public DateTime CreatedAt { get; init; }
+
+	/// <summary>
+	/// Пользователь, который последний раз обновлял комментарий.
+	/// </summary>
+	public string? UpdatedBy { get; init; }
+
+	/// <summary>
+	/// Дата и время последнего обновления комментария.
+	/// </summary>
+	public DateTime? UpdatedAt { get; init; }
+}

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/ImportIssueRequest.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Requests/Create/ImportIssueRequest.cs
@@ -1,0 +1,83 @@
+// Copyright 2024 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Mindbox.YandexTracker;
+
+/// <summary>
+/// Запрос на импорт задачи в Яндекс.Трекер.
+/// </summary>
+/// <remarks>
+/// Должен вызываться только администратором системы.
+/// В отличие от <see cref="CreateIssueRequest"/>, позволяет указать дату создания из прошлого,
+/// а также в качестве создателя задачи указать любого пользователя.
+/// </remarks>
+public record ImportIssueRequest : CreateIssueRequest
+{
+	/// <summary>
+	/// Дата и время создания задачи.
+	/// </summary>
+	/// <remarks>
+	/// Не может быть позже текущего времени.
+	/// </remarks>
+	public DateTime CreatedAt { get; init; }
+
+	/// <summary>
+	/// Логин или идентификатор автора задачи.
+	/// </summary>
+	public required string CreatedBy { get; init; }
+
+	/// <summary>
+	/// Дата и время последнего изменения задачи.
+	/// </summary>
+	/// <remarks>
+	/// Не может быть позже текущего времени.
+	/// Параметр указывается только вместе с <see cref="UpdatedBy"/>.
+	/// </remarks>
+	public DateTime? UpdatedAt { get; init; }
+
+	/// <summary>
+	/// Логин или идентификатор пользователя, который последний редактировал задачу.
+	/// </summary>
+	/// <remarks>
+	/// Параметр указывается только вместе с <see cref="UpdatedAt"/>.
+	/// </remarks>
+	public string? UpdatedBy { get; init; }
+
+	/// <summary>
+	/// Дата и время проставления резолюции.
+	/// </summary>
+	/// <remarks>
+	/// Вы можете указать любое значение в интервале времени от создания до последнего изменения задачи.
+	/// Параметр указывается только вместе с <see cref="ResolvedBy"/>.
+	/// </remarks>
+	public DateTime? ResolvedAt { get; init; }
+
+	/// <summary>
+	/// Логин или идентификатор пользователя, который последний редактировал задачу.
+	/// </summary>
+	/// <remarks>
+	/// Параметр указывается только вместе с <see cref="ResolvedAt"/> и <see cref="Resolution"/>.
+	/// </remarks>
+	public string? ResolvedBy { get; init; }
+
+	/// <summary>
+	/// Идентификатор резолюции задачи.
+	/// </summary>
+	/// <remarks>
+	/// Параметр указывается только вместе с <see cref="ResolvedAt"/> и <see cref="ResolvedBy"/>.
+	/// </remarks>
+	public long? Resolution { get; init; }
+}

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/CreateAttachmentResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/CreateAttachmentResponse.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@ using System;
 
 namespace Mindbox.YandexTracker;
 
-public sealed record CreateAttachmentResponse
+public record CreateAttachmentResponse
 {
 	public required string Id { get; init; }
 

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/CreateCommentResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/CreateCommentResponse.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 
 namespace Mindbox.YandexTracker;
 
-public sealed record CreateCommentResponse
+public record CreateCommentResponse
 {
 	public int Id { get; init; }
 
@@ -29,9 +29,9 @@ public sealed record CreateCommentResponse
 
 	public required UserShortInfoDto CreatedBy { get; init; }
 
-	public required UserShortInfoDto UpdatedBy { get; init; }
-
 	public DateTime CreatedAt { get; init; }
+
+	public required UserShortInfoDto UpdatedBy { get; init; }
 
 	public DateTime UpdatedAt { get; init; }
 

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/CreateIssueResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/CreateIssueResponse.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,61 +17,44 @@ using System.Collections.Generic;
 
 namespace Mindbox.YandexTracker;
 
-public sealed record CreateIssueResponse : CustomFieldsResponse
+/// <summary>
+/// Ответ на запрос создания задачи <see cref="CreateIssueRequest"/>.
+/// </summary>
+public record CreateIssueResponse : CustomFieldsResponse
 {
 	public required string Id { get; init; }
 
 	public required string Key { get; init; }
 
+	public required FieldInfo Queue { get; init; }
+
 	public required int Version { get; init; }
 
 	public required string Summary { get; init; }
 
-	public DateTime? LastCommentUpdatedAt { get; init; }
-
 	public FieldInfo? Parent { get; init; }
-
-	public required UserShortInfoDto UpdatedBy { get; init; }
-
-	public UserShortInfoDto? Author { get; init; }
-
-	public UserShortInfoDto? QaEngineer { get; init; }
-
-	public IReadOnlyCollection<UserShortInfoDto> Access { get; init; } = [];
-
-	public int? PossibleSpam { get; init; }
-
-	public string? Description { get; init; }
-
-	public IReadOnlyCollection<FieldInfo> Sprint { get; init; } = [];
-
-	public IReadOnlyCollection<UserShortInfoDto> Followers { get; init; } = [];
-
-	public IReadOnlyCollection<string> Aliases { get; init; } = [];
-
-	public required FieldInfo Type { get; init; }
-
-	public required FieldInfo Priority { get; init; }
 
 	public DateTime CreatedAt { get; init; }
 
 	public required UserShortInfoDto CreatedBy { get; init; }
 
-	public int Votes { get; init; }
+	public DateTime? UpdatedAt { get; init; }
 
-	public UserShortInfoDto? Assignee { get; init; }
+	public UserShortInfoDto? UpdatedBy { get; init; }
 
-	public FieldInfo? Project { get; init; }
-
-	public required FieldInfo Queue { get; init; }
-
-	public DateTime UpdatedAt { get; init; }
+	public required FieldInfo Type { get; init; }
 
 	public required FieldInfo Status { get; init; }
 
+	public DateTime? StatusStartTime { get; init; }
+
 	public FieldInfo? PreviousStatus { get; init; }
 
-	public bool Favorite { get; init; }
+	public string? Description { get; init; }
+
+	public UserShortInfoDto? Author { get; init; }
+
+	public UserShortInfoDto? Assignee { get; init; }
 
 	public DateOnly? Start { get; init; }
 
@@ -79,5 +62,27 @@ public sealed record CreateIssueResponse : CustomFieldsResponse
 
 	public DateOnly? DueDate { get; init; }
 
-	public DateTime? StatusStartTime { get; init; }
+	public double? StoryPoints { get; init; }
+
+	public FieldInfo? Project { get; init; }
+
+	public IReadOnlyCollection<FieldInfo> Sprint { get; init; } = [];
+
+	public IReadOnlyCollection<UserShortInfoDto> Followers { get; init; } = [];
+
+	public IReadOnlyCollection<string> Aliases { get; init; } = [];
+
+	public required FieldInfo Priority { get; init; }
+
+	public int Votes { get; init; }
+
+	public bool Favorite { get; init; }
+
+	public IReadOnlyCollection<UserShortInfoDto> Access { get; init; } = [];
+
+	public int? PossibleSpam { get; init; }
+
+	public UserShortInfoDto? QaEngineer { get; init; }
+
+	public DateTime? LastCommentUpdatedAt { get; init; }
 }

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportAttachmentResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportAttachmentResponse.cs
@@ -1,3 +1,17 @@
+// Copyright 2024 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Mindbox.YandexTracker;
 
 /// <summary>

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportAttachmentResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportAttachmentResponse.cs
@@ -1,0 +1,8 @@
+namespace Mindbox.YandexTracker;
+
+/// <summary>
+/// Ответ на запрос импорта вложения к задаче или комментарию.
+/// </summary>
+public record ImportAttachmentResponse : CreateAttachmentResponse
+{
+}

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportCommentResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportCommentResponse.cs
@@ -1,3 +1,17 @@
+// Copyright 2024 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Mindbox.YandexTracker;
 
 /// <summary>

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportCommentResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportCommentResponse.cs
@@ -1,0 +1,8 @@
+namespace Mindbox.YandexTracker;
+
+/// <summary>
+/// Ответ на запрос импорта комментария к задаче <see cref="ImportCommentRequest"/>.
+/// </summary>
+public record ImportCommentResponse : CreateCommentResponse
+{
+}

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportIssueResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Create/ImportIssueResponse.cs
@@ -1,0 +1,29 @@
+// Copyright 2024 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Mindbox.YandexTracker;
+
+/// <summary>
+/// Ответ на запрос импорта задачи <see cref="ImportIssueRequest"/>.
+/// </summary>
+public record ImportIssueResponse : CreateIssueResponse
+{
+	public DateTime? ResolvedAt { get; init; }
+
+	public UserShortInfoDto? ResolvedBy { get; init; }
+
+	public FieldInfo? Resolution { get; init; }
+}

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetIssueResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetIssueResponse.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 
 namespace Mindbox.YandexTracker;
 
-public sealed record GetIssueResponse : CustomFieldsResponse
+public record GetIssueResponse : CustomFieldsResponse
 {
 	public required string Id { get; init; }
 

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetIssueResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetIssueResponse.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,55 +22,53 @@ public sealed record GetIssueResponse : CustomFieldsResponse
 	public required string Id { get; init; }
 
 	public required string Key { get; init; }
+
+	public IReadOnlyCollection<string> Aliases { get; init; } = [];
+
+	public required FieldInfo Queue { get; init; }
+
 	public required int Version { get; init; }
 
 	public required string Summary { get; init; }
 
-	public DateTime? LastCommentUpdatedAt { get; init; }
-
-	public FieldInfo? Parent { get; init; }
-
-	public IReadOnlyCollection<string> Aliases { get; init; } = [];
-
-	public required UserShortInfoDto UpdatedBy { get; init; }
-
-	public string? Description { get; init; }
-
-	public IReadOnlyCollection<FieldInfo> Sprint { get; init; } = [];
-
-	public required FieldInfo Type { get; init; }
-
-	public UserShortInfoDto? Author { get; init; }
-
-	public UserShortInfoDto? QaEngineer { get; init; }
-
-	public IReadOnlyCollection<UserShortInfoDto> Access { get; init; } = [];
-
-	public int? PossibleSpam { get; init; }
-
-	public required FieldInfo Priority { get; init; }
-
 	public DateTime CreatedAt { get; init; }
-
-	public IReadOnlyCollection<UserShortInfoDto> Followers { get; init; } = [];
 
 	public required UserShortInfoDto CreatedBy { get; init; }
 
-	public int Votes { get; init; }
-
-	public UserShortInfoDto? Assignee { get; init; }
-
-	public FieldInfo? Project { get; init; }
-
-	public required FieldInfo Queue { get; init; }
+	public UserShortInfoDto? Author { get; init; }
 
 	public DateTime UpdatedAt { get; init; }
 
+	public required UserShortInfoDto UpdatedBy { get; init; }
+
+
+	public DateTime? ResolvedAt { get; init; }
+
+	public UserShortInfoDto? ResolvedBy { get; init; }
+
+	public FieldInfo? Resolution { get; init; }
+
+	public required FieldInfo Type { get; init; }
+
 	public required FieldInfo Status { get; init; }
+
+	public DateTime? StatusStartTime { get; init; }
 
 	public FieldInfo? PreviousStatus { get; init; }
 
-	public bool Favorite { get; init; }
+	public string? Description { get; init; }
+
+	public FieldInfo? Parent { get; init; }
+
+	public required FieldInfo Priority { get; init; }
+
+	public UserShortInfoDto? Assignee { get; init; }
+
+	public double? StoryPoints { get; init; }
+
+	public FieldInfo? Project { get; init; }
+
+	public IReadOnlyCollection<FieldInfo> Sprint { get; init; } = [];
 
 	public DateOnly? Start { get; set; }
 
@@ -78,6 +76,19 @@ public sealed record GetIssueResponse : CustomFieldsResponse
 
 	public DateOnly? DueDate { get; set; }
 
-	public DateTime? StatusStartTime { get; init; }
 	public IReadOnlyCollection<string> Tags { get; init; } = [];
+
+	public IReadOnlyCollection<UserShortInfoDto> Access { get; init; } = [];
+
+	public int? PossibleSpam { get; init; }
+
+	public UserShortInfoDto? QaEngineer { get; init; }
+
+	public IReadOnlyCollection<UserShortInfoDto> Followers { get; init; } = [];
+
+	public int Votes { get; init; }
+
+	public bool Favorite { get; init; }
+
+	public DateTime? LastCommentUpdatedAt { get; init; }
 }

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetIssueResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetIssueResponse.cs
@@ -91,4 +91,6 @@ public record GetIssueResponse : CustomFieldsResponse
 	public bool Favorite { get; init; }
 
 	public DateTime? LastCommentUpdatedAt { get; init; }
+
+	public IReadOnlyCollection<FieldInfo> Attachments { get; init; } = [];
 }

--- a/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetProjectsResponse.cs
+++ b/Mindbox.YandexTracker.Abstractions/Dtos/Responses/Read/GetProjectsResponse.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,7 +28,7 @@ public sealed record GetProjectsResponse
 	public string? OrderBy { get; init; }
 }
 
-public sealed record ProjectInfo
+public record ProjectInfo
 {
 	public required string Id { get; init; }
 
@@ -47,7 +47,7 @@ public sealed record ProjectInfo
 	public ProjectInfoFields? Fields { get; init; }
 }
 
-public sealed record ProjectInfoFields
+public record ProjectInfoFields
 {
 	public string? Summary { get; init; }
 

--- a/Mindbox.YandexTracker.Abstractions/Enums/ProjectEntityStatus.cs
+++ b/Mindbox.YandexTracker.Abstractions/Enums/ProjectEntityStatus.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,8 +22,11 @@ namespace Mindbox.YandexTracker;
 public enum ProjectEntityStatus
 {
 	/// <summary>
-	/// Черновик
+	/// Новый.
 	/// </summary>
+	/// <remarks>
+	/// В доке указывается Черновик, но в реальности в UI отображается Новый.
+	/// </remarks>
 	[EnumMember(Value = "draft")]
 	Draft,
 
@@ -34,8 +37,11 @@ public enum ProjectEntityStatus
 	InProgress,
 
 	/// <summary>
-	/// Новый
+	/// Завершен.
 	/// </summary>
+	/// <remarks>
+	/// В доке указывается Новый, но в реальности в UI отображается Завершен.
+	/// </remarks>
 	[EnumMember(Value = "launched")]
 	Launched,
 

--- a/Mindbox.YandexTracker.Abstractions/IYandexTrackerClient.cs
+++ b/Mindbox.YandexTracker.Abstractions/IYandexTrackerClient.cs
@@ -142,7 +142,7 @@ public interface IYandexTrackerClient : IDisposable
 		CancellationToken cancellationToken = default);
 
 	/// <summary>
-	/// Создает комментарий
+	/// Создает комментарий к задаче.
 	/// </summary>
 	/// <param name="issueKey">Ключ задачи</param>
 	/// <param name="request">Запрос</param>
@@ -157,6 +157,21 @@ public interface IYandexTrackerClient : IDisposable
 		string issueKey,
 		CreateCommentRequest request,
 		bool? addAuthorToFollowers = null,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Импортирует комментарий в задачу.
+	/// </summary>
+	/// <param name="issueKey">Ключ задачи</param>
+	/// <param name="request">Запрос</param>
+	/// <param name="cancellationToken"></param>
+	/// <returns></returns>
+	/// <remarks>
+	/// <see href="https://yandex.ru/support/tracker/ru/concepts/import/import-comments"/>
+	/// </remarks>
+	Task<ImportCommentResponse> ImportCommentAsync(
+		string issueKey,
+		ImportCommentRequest request,
 		CancellationToken cancellationToken = default);
 
 	/// <remarks>
@@ -184,6 +199,42 @@ public interface IYandexTrackerClient : IDisposable
 		string? newFileName = null,
 		CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// Импортирует вложение в задачу.
+	/// </summary>
+	/// <remarks>
+	/// В отличие от <see cref="CreateAttachmentAsync"/> или <see cref="CreateTemporaryAttachmentAsync"/>,
+	/// позволяет указать дату создания вложения и пользователя, который создал вложение.
+	/// <see href="https://yandex.ru/support/tracker/ru/concepts/import/import-attachments"/>
+	/// </remarks>
+	Task<ImportAttachmentResponse> ImportAttachmentToIssueAsync(
+		string issueKey,
+		Stream fileStream,
+		string newFileName,
+		DateTime createdAt,
+		string createdBy,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Импортирует вложение в комментарий задачи.
+	/// </summary>
+	/// <remarks>
+	/// В отличие от <see cref="CreateAttachmentAsync"/> или <see cref="CreateTemporaryAttachmentAsync"/>,
+	/// позволяет указать дату создания вложения и пользователя, который создал вложение.
+	/// <see href="https://yandex.ru/support/tracker/ru/concepts/import/import-attachments"/>
+	/// </remarks>
+	Task<ImportAttachmentResponse> ImportAttachmentToIssueCommentAsync(
+		string issueKey,
+		string commentId,
+		Stream fileStream,
+		string newFileName,
+		DateTime createdAt,
+		string createdBy,
+		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Создает временное вложение, которое потом должно быть прикреплено к задаче, комментарию или сущности (проект/портфель).
+	/// </summary>
 	/// <remarks>
 	/// <see href="https://yandex.cloud/ru/docs/tracker/concepts/issues/temp-attachment"/>
 	/// </remarks>

--- a/Mindbox.YandexTracker.Abstractions/IYandexTrackerClient.cs
+++ b/Mindbox.YandexTracker.Abstractions/IYandexTrackerClient.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -97,10 +97,26 @@ public interface IYandexTrackerClient : IDisposable
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// Создает новую задачу.
+	/// </summary>
 	/// <remarks>
 	/// <see href="https://yandex.ru/support/tracker/ru/concepts/issues/create-issue"/>
 	/// </remarks>
 	Task<CreateIssueResponse> CreateIssueAsync(CreateIssueRequest request, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Импортирует новую задачу в Трекер.
+	/// </summary>
+	/// <remarks>
+	/// ВАЖНО: Должен вызываться только от администратора системы.
+	/// В отличие от <see cref="CreateIssueAsync"/>, позволяет:
+	/// - указать дату создания тикета и пользователя, который создал тикет;
+	/// - последнюю дату изменения тикета и пользователя, который последний раз изменял тикет;
+	/// - дату и время проставления резолюции и пользователя, который проставил резолюцию.
+	///  <see href="https://yandex.cloud/ru/docs/tracker/concepts/import/import-ticket"/>
+	/// </remarks>
+	Task<ImportIssueResponse> ImportIssueAsync(ImportIssueRequest request, CancellationToken cancellationToken = default);
 
 	/// <remarks>
 	/// <see href="https://yandex.ru/support/tracker/ru/get-components"/>

--- a/Mindbox.YandexTracker.Template/YandexTrackerClientCachingDecorator.cs
+++ b/Mindbox.YandexTracker.Template/YandexTrackerClientCachingDecorator.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -39,6 +40,44 @@ public sealed class YandexTrackerClientCachingDecorator(
 	}
 
 	/// <inheritdoc />
+	public Task<ImportAttachmentResponse> ImportAttachmentToIssueAsync(
+		string issueKey,
+		Stream fileStream,
+		string newFileName,
+		DateTime createdAt,
+		string createdBy,
+		CancellationToken cancellationToken = default)
+	{
+		return yandexTrackerClient.ImportAttachmentToIssueAsync(
+			issueKey,
+			fileStream,
+			newFileName,
+			createdAt,
+			createdBy,
+			cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public Task<ImportAttachmentResponse> ImportAttachmentToIssueCommentAsync(
+		string issueKey,
+		string commentId,
+		Stream fileStream,
+		string newFileName,
+		DateTime createdAt,
+		string createdBy,
+		CancellationToken cancellationToken = default)
+	{
+		return yandexTrackerClient.ImportAttachmentToIssueCommentAsync(
+			issueKey,
+			commentId,
+			fileStream,
+			newFileName,
+			createdAt,
+			createdBy,
+			cancellationToken);
+	}
+
+	/// <inheritdoc />
 	public Task<CreateAttachmentResponse> CreateTemporaryAttachmentAsync(
 		Stream fileStream,
 		string? newFileName = null,
@@ -55,6 +94,14 @@ public sealed class YandexTrackerClientCachingDecorator(
 		CancellationToken cancellationToken = default)
 	{
 		return yandexTrackerClient.CreateCommentAsync(issueKey, request, addAuthorToFollowers, cancellationToken);
+	}
+
+	public Task<ImportCommentResponse> ImportCommentAsync(
+		string issueKey,
+		ImportCommentRequest request,
+		CancellationToken cancellationToken = default)
+	{
+		return yandexTrackerClient.ImportCommentAsync(issueKey, request, cancellationToken);
 	}
 
 	/// <inheritdoc />

--- a/Mindbox.YandexTracker.Template/YandexTrackerClientCachingDecorator.cs
+++ b/Mindbox.YandexTracker.Template/YandexTrackerClientCachingDecorator.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -61,6 +61,12 @@ public sealed class YandexTrackerClientCachingDecorator(
 	public Task<CreateIssueResponse> CreateIssueAsync(CreateIssueRequest request, CancellationToken cancellationToken = default)
 	{
 		return yandexTrackerClient.CreateIssueAsync(request, cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public Task<ImportIssueResponse> ImportIssueAsync(ImportIssueRequest request, CancellationToken cancellationToken = default)
+	{
+		return yandexTrackerClient.ImportIssueAsync(request, cancellationToken);
 	}
 
 	/// <inheritdoc />

--- a/Mindbox.YandexTracker.Tests/IntegrationsTests/SafeExecutor.cs
+++ b/Mindbox.YandexTracker.Tests/IntegrationsTests/SafeExecutor.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Mindbox.YandexTracker.Tests;
+
+public static class SafeExecutor
+{
+	public static async Task ExecuteAsync(Func<Task> action)
+	{
+		try
+		{
+			await action();
+		}
+		catch
+		{
+			// ignored
+		}
+	}
+}

--- a/Mindbox.YandexTracker.Tests/IntegrationsTests/SafeExecutor.cs
+++ b/Mindbox.YandexTracker.Tests/IntegrationsTests/SafeExecutor.cs
@@ -1,3 +1,17 @@
+// Copyright 2024 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Threading.Tasks;
 

--- a/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
+++ b/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
@@ -447,13 +447,13 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 	public async Task GetComponentsAsync_ResponseIsNotNullAndNotEmpty()
 	{
 		var component1 = await YandexTrackerClient.CreateComponentAsync(
-			new CreateComponentRequest()
+			new CreateComponentRequest
 			{
 				Name = GetUniqueName(),
 				Queue = TestQueueKey
 			});
 		var component2 = await YandexTrackerClient.CreateComponentAsync(
-			new CreateComponentRequest()
+			new CreateComponentRequest
 			{
 				Name = GetUniqueName(),
 				Queue = TestQueueKey
@@ -594,51 +594,6 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 	}
 
 	[TestMethod]
-	public async Task ImportComment_WithTempAttachments()
-	{
-		var issue = await YandexTrackerClient.CreateIssueAsync(new CreateIssueRequest
-		{
-			Queue = TestQueueKey,
-			Summary = GetUniqueName()
-		});
-
-		await using var imageFile = File.OpenRead(Path.Combine("TestFiles", "pepe.png"));
-		await using var txtFile = File.OpenRead(Path.Combine("TestFiles", "importantInformation.txt"));
-
-		var imageAttachment = await YandexTrackerClient.CreateTemporaryAttachmentAsync(imageFile, "pepe.png");
-		var textAttachment = await YandexTrackerClient.CreateTemporaryAttachmentAsync(txtFile, "info.txt");
-
-		var createdAt = new DateTime(2024, 10, 10, 10, 10, 10);
-		var updatedAt = createdAt.AddMinutes(10);
-		await YandexTrackerClient.ImportCommentAsync(issue.Key, new ImportCommentRequest
-		{
-			CreatedBy = CurrentUserId,
-			CreatedAt = createdAt,
-			UpdatedBy = CurrentUserId,
-			UpdatedAt = updatedAt,
-			Text = "This comment has image",
-		});
-
-		await YandexTrackerClient.ImportCommentAsync(issue.Key, new ImportCommentRequest
-		{
-			CreatedBy = CurrentUserId,
-			CreatedAt = createdAt,
-			UpdatedBy = CurrentUserId,
-			UpdatedAt = updatedAt,
-			Text = "This comment has file",
-		});
-
-		await Task.Delay(1000); // Чтобы комментарии точно создались в трекере
-
-		var comments = (await YandexTrackerClient.GetCommentsAsync(issue.Key, CommentExpandData.Attachments)).Values;
-
-		Assert.IsNotNull(comments);
-		Assert.AreEqual(2, comments.Count);
-		Assert.AreEqual(imageAttachment.Id, comments[0].Attachments.First().Id);
-		Assert.AreEqual(textAttachment.Id, comments[^1].Attachments.First().Id);
-	}
-
-	[TestMethod]
 	public async Task GetTagsAsync_ResponseIsNotNull()
 	{
 		var response = await YandexTrackerClient.GetTagsAsync(TestQueueKey);
@@ -652,7 +607,7 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 		// Arrange
 		var summary = GetUniqueName();
 
-		var currentUserShortInfo = new UserShortInfoDto()
+		var currentUserShortInfo = new UserShortInfoDto
 		{
 			Display = CurrentUserLogin,
 			Id = CurrentUserId
@@ -671,7 +626,7 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 				ProjectEntityType.Project,
 				new CreateProjectRequest
 				{
-					Fields = new ProjectFieldsDto()
+					Fields = new ProjectFieldsDto
 					{
 						Summary = summary,
 						Author = currentUserShortInfo.Id,
@@ -691,9 +646,9 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 
 			await Task.Delay(1000); // Чтобы проекты точно создались в трекере
 
-			var requestProject = new GetProjectsRequest()
+			var requestProject = new GetProjectsRequest
 			{
-				Filter = new ProjectFieldsDto()
+				Filter = new ProjectFieldsDto
 				{
 					Summary = summary
 				}

--- a/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
+++ b/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
@@ -141,6 +141,7 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 		{
 			Queue = TestQueueKey,
 			Summary = GetUniqueName(),
+			Project = TestProjectShortId
 		};
 
 		issue.SetCustomField<string>(customField.Id, "field1");

--- a/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
+++ b/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
@@ -159,6 +159,7 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 	}
 
 	[TestMethod]
+	[Ignore("Методы должны вызываться только администратором Яндекс.Трекера. В CI/CD используется обычный пользователь")]
 	public async Task FullImportIssueFlow()
 	{
 		var firstCategory = (await YandexTrackerClient.GetFieldCategoriesAsync()).Values[0];

--- a/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
+++ b/Mindbox.YandexTracker.Tests/IntegrationsTests/YandexTrackerClientTests.cs
@@ -514,6 +514,51 @@ public class YandexTrackerClientTests : YandexTrackerTestBase
 	}
 
 	[TestMethod]
+	public async Task ImportComment_WithTempAttachments()
+	{
+		var issue = await YandexTrackerClient.CreateIssueAsync(new CreateIssueRequest
+		{
+			Queue = TestQueueKey,
+			Summary = GetUniqueName()
+		});
+
+		await using var imageFile = File.OpenRead(Path.Combine("TestFiles", "pepe.png"));
+		await using var txtFile = File.OpenRead(Path.Combine("TestFiles", "importantInformation.txt"));
+
+		var imageAttachment = await YandexTrackerClient.CreateTemporaryAttachmentAsync(imageFile, "pepe.png");
+		var textAttachment = await YandexTrackerClient.CreateTemporaryAttachmentAsync(txtFile, "info.txt");
+
+		var createdAt = new DateTime(2024, 10, 10, 10, 10, 10);
+		var updatedAt = createdAt.AddMinutes(10);
+		await YandexTrackerClient.ImportCommentAsync(issue.Key, new ImportCommentRequest
+		{
+			CreatedBy = CurrentUserId,
+			CreatedAt = createdAt,
+			UpdatedBy = CurrentUserId,
+			UpdatedAt = updatedAt,
+			Text = "This comment has image",
+		});
+
+		await YandexTrackerClient.ImportCommentAsync(issue.Key, new ImportCommentRequest
+		{
+			CreatedBy = CurrentUserId,
+			CreatedAt = createdAt,
+			UpdatedBy = CurrentUserId,
+			UpdatedAt = updatedAt,
+			Text = "This comment has file",
+		});
+
+		await Task.Delay(1000); // Чтобы комментарии точно создались в трекере
+
+		var comments = (await YandexTrackerClient.GetCommentsAsync(issue.Key, CommentExpandData.Attachments)).Values;
+
+		Assert.IsNotNull(comments);
+		Assert.AreEqual(2, comments.Count);
+		Assert.AreEqual(imageAttachment.Id, comments[0].Attachments.First().Id);
+		Assert.AreEqual(textAttachment.Id, comments[^1].Attachments.First().Id);
+	}
+
+	[TestMethod]
 	public async Task GetTagsAsync_ResponseIsNotNull()
 	{
 		var response = await YandexTrackerClient.GetTagsAsync(TestQueueKey);

--- a/Mindbox.YandexTracker.Tests/Mindbox.YandexTracker.Tests.csproj
+++ b/Mindbox.YandexTracker.Tests/Mindbox.YandexTracker.Tests.csproj
@@ -9,6 +9,7 @@
         <PackageReference Include="AutoFixture" Version="4.18.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
@@ -20,6 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Mindbox.YandexTracker.Template\Mindbox.YandexTracker.Template.csproj" />
       <ProjectReference Include="..\Mindbox.YandexTracker\Mindbox.YandexTracker.csproj" />
     </ItemGroup>
   

--- a/Mindbox.YandexTracker.Tests/YandexTrackerTestBase.cs
+++ b/Mindbox.YandexTracker.Tests/YandexTrackerTestBase.cs
@@ -100,7 +100,7 @@ public abstract class YandexTrackerTestBase
 	{
 		var project = await YandexTrackerClient.CreateProjectAsync(
 			ProjectEntityType.Project,
-			new CreateProjectRequest()
+			new CreateProjectRequest
 			{
 				Fields = new ProjectFieldsDto
 				{

--- a/Mindbox.YandexTracker.Tests/YandexTrackerTestBase.cs
+++ b/Mindbox.YandexTracker.Tests/YandexTrackerTestBase.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,16 +14,21 @@
 
 using System;
 using System.Globalization;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mindbox.YandexTracker.Template;
+using Polly;
 
 namespace Mindbox.YandexTracker.Tests;
 
 public abstract class YandexTrackerTestBase
 {
 	protected static string TestQueueKey { get; private set; } = null!;
+	protected static int TestProjectShortId { get; private set; }
 	protected static string CurrentUserId { get; private set; } = null!;
 	protected static string CurrentUserLogin { get; private set; } = null!;
 	protected static IServiceProvider ServiceProvider { get; private set; } = null!;
@@ -53,16 +58,21 @@ public abstract class YandexTrackerTestBase
 
 		// в ключе может быть до 15 латинских символов
 		TestQueueKey = $"TEST{StringHelper.GetUniqueString(length: 11)}";
-		await CreateQueueAsync();
+		await CreateTestQueueAsync();
+		await CreateTestProjectAsync();
 	}
 
 	[ClassCleanup(InheritanceBehavior.BeforeEachDerivedClass)]
 	public static async Task TestCleanupAsync()
 	{
-		await YandexTrackerClient.DeleteQueueAsync(TestQueueKey);
+		await SafeExecutor.ExecuteAsync(async () => await YandexTrackerClient.DeleteQueueAsync(TestQueueKey));
+		await SafeExecutor.ExecuteAsync(async () => await YandexTrackerClient.DeleteProjectAsync(
+			ProjectEntityType.Project,
+			TestProjectShortId,
+			true));
 	}
 
-	private static async Task CreateQueueAsync()
+	private static async Task CreateTestQueueAsync()
 	{
 		await YandexTrackerClient.CreateQueueAsync(new CreateQueueRequest
 		{
@@ -82,12 +92,43 @@ public abstract class YandexTrackerTestBase
 		});
 	}
 
+	private static async Task CreateTestProjectAsync()
+	{
+		var project = await YandexTrackerClient.CreateProjectAsync(
+			ProjectEntityType.Project,
+			new CreateProjectRequest()
+			{
+				Fields = new ProjectFieldsDto
+				{
+					Summary = "Yandex Tracker CI/CD Test"
+				}
+			});
+		TestProjectShortId = project.ShortId;
+	}
+
 	private static void SetupServices(IServiceCollection services, IConfigurationRoot configuration)
 	{
-		services
-			.AddHttpClient()
-			.Configure<YandexTrackerClientOptions>(configuration.GetSection("YandexTrackerOptions"))
-			.AddScoped<IYandexTrackerClient, YandexTrackerClient>();
+		services.Configure<YandexTrackerClientOptions>(configuration.GetSection("YandexTrackerOptions"));
+		services.AddYandexTrackerClient(enableCaching: false)
+			.AddResilienceHandler("ResilienceStrategy", builder =>
+			{
+				builder.AddRetry(new HttpRetryStrategyOptions
+				{
+					MaxRetryAttempts = 3,
+					Delay = TimeSpan.FromMilliseconds(1500),
+					BackoffType = DelayBackoffType.Exponential,
+					UseJitter = true,
+					ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+						.Handle<HttpRequestException>()
+						.HandleResult(response =>
+						{
+							int statusCode = (int)response.StatusCode;
+							return statusCode is >= 500 or 429 or 404 or 400;
+						})
+				});
+
+				builder.AddTimeout(TimeSpan.FromSeconds(5));
+			});
 	}
 
 	protected static T GetRequiredService<T>() where T : notnull

--- a/Mindbox.YandexTracker/JsonConverters/YandexDateTimeJsonConverter.cs
+++ b/Mindbox.YandexTracker/JsonConverters/YandexDateTimeJsonConverter.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,6 @@ namespace Mindbox.YandexTracker.JsonConverters;
 /// </summary>
 internal class YandexDateTimeJsonConverter : JsonConverter<DateTime>
 {
-	private const string DateFormat = "yyyy-MM-ddTHH:mm:ss.fffzzz"; // Adjust this to match your JSON date format
 
 	public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
@@ -33,7 +32,7 @@ internal class YandexDateTimeJsonConverter : JsonConverter<DateTime>
 		var dateString = reader.GetString();
 		if (DateTime.TryParseExact(
 				dateString,
-				DateFormat,
+				YandexTrackerConstants.DateTimeFormat,
 				CultureInfo.InvariantCulture,
 				DateTimeStyles.None, out DateTime date))
 		{
@@ -45,6 +44,6 @@ internal class YandexDateTimeJsonConverter : JsonConverter<DateTime>
 
 	public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
 	{
-		writer.WriteStringValue(value.ToString(DateFormat, CultureInfo.InvariantCulture));
+		writer.WriteStringValue(value.ToString(YandexTrackerConstants.DateTimeFormat, CultureInfo.InvariantCulture));
 	}
 }

--- a/Mindbox.YandexTracker/JsonConverters/YandexNullableDateTimeJsonConverter.cs
+++ b/Mindbox.YandexTracker/JsonConverters/YandexNullableDateTimeJsonConverter.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,8 +24,6 @@ namespace Mindbox.YandexTracker.JsonConverters;
 /// </summary>
 internal class YandexNullableDateTimeJsonConverter : JsonConverter<DateTime?>
 {
-	private const string DateFormat = "yyyy-MM-ddTHH:mm:ss.fffzzz"; // Adjust this to match your JSON date format
-
 	public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
 		if (reader.TokenType != JsonTokenType.String) throw new JsonException("Expected date string");
@@ -35,7 +33,7 @@ internal class YandexNullableDateTimeJsonConverter : JsonConverter<DateTime?>
 
 		if (DateTime.TryParseExact(
 				dateString,
-				DateFormat,
+				YandexTrackerConstants.DateTimeFormat,
 				CultureInfo.InvariantCulture,
 				DateTimeStyles.None, out DateTime date))
 		{
@@ -47,6 +45,6 @@ internal class YandexNullableDateTimeJsonConverter : JsonConverter<DateTime?>
 
 	public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
 	{
-		writer.WriteStringValue(value?.ToString(DateFormat, CultureInfo.InvariantCulture));
+		writer.WriteStringValue(value?.ToString(YandexTrackerConstants.DateTimeFormat, CultureInfo.InvariantCulture));
 	}
 }

--- a/Mindbox.YandexTracker/YandexTrackerClient.cs
+++ b/Mindbox.YandexTracker/YandexTrackerClient.cs
@@ -1,11 +1,11 @@
 // Copyright 2024 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -273,14 +273,26 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<CreateIssueResponse> CreateIssueAsync(
+	public Task<CreateIssueResponse> CreateIssueAsync(
 		CreateIssueRequest request,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(request);
 
-		return await ExecuteYandexTrackerApiRequestAsync<CreateIssueResponse>(
+		return ExecuteYandexTrackerApiRequestAsync<CreateIssueResponse>(
 			"issues",
+			HttpMethod.Post,
+			payload: request,
+			cancellationToken: cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public Task<ImportIssueResponse> ImportIssueAsync(ImportIssueRequest request, CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(request);
+
+		return ExecuteYandexTrackerApiRequestAsync<ImportIssueResponse>(
+			"issues/_import ",
 			HttpMethod.Post,
 			payload: request,
 			cancellationToken: cancellationToken);

--- a/Mindbox.YandexTracker/YandexTrackerClient.cs
+++ b/Mindbox.YandexTracker/YandexTrackerClient.cs
@@ -91,7 +91,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<GetQueuesResponse> GetQueueAsync(
+	public Task<GetQueuesResponse> GetQueueAsync(
 		string queueKey,
 		QueueExpandData? expand = null,
 		CancellationToken cancellationToken = default)
@@ -105,7 +105,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			parameters["expand"] = expand.Value.ToYandexQueryString(QueueExpandData.All, QueueExpandData.None);
 		}
 
-		return await ExecuteYandexTrackerApiRequestAsync<GetQueuesResponse>(
+		return ExecuteYandexTrackerApiRequestAsync<GetQueuesResponse>(
 			$"queues/{queueKey}",
 			HttpMethod.Get,
 			payload: null,
@@ -114,7 +114,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetQueuesResponse>> GetQueuesAsync(
+	public Task<YandexTrackerCollectionResponse<GetQueuesResponse>> GetQueuesAsync(
 		QueuesExpandData? expand = null,
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
@@ -126,7 +126,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			parameters["expand"] = expand.Value.ToYandexQueryString(null, QueuesExpandData.None);
 		}
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetQueuesResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetQueuesResponse>(
 			"queues",
 			HttpMethod.Get,
 			parameters: parameters,
@@ -135,7 +135,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<GetIssueResponse> GetIssueAsync(
+	public Task<GetIssueResponse> GetIssueAsync(
 		string issueKey,
 		IssueExpandData? expand = null,
 		CancellationToken cancellationToken = default)
@@ -149,7 +149,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			parameters["expand"] = expand.Value.ToYandexQueryString(null, IssueExpandData.None);
 		}
 
-		return await ExecuteYandexTrackerApiRequestAsync<GetIssueResponse>(
+		return ExecuteYandexTrackerApiRequestAsync<GetIssueResponse>(
 			$"issues/{issueKey}",
 			HttpMethod.Get,
 			payload: null!,
@@ -158,7 +158,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesFromQueueAsync(
+	public Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesFromQueueAsync(
 		string queueKey,
 		IssuesExpandData? expand = null,
 		PaginationSettings? paginationSettings = null,
@@ -178,7 +178,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			Queue = queueKey
 		};
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
 			"issues/_search",
 			HttpMethod.Post,
 			payload: request,
@@ -188,7 +188,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesByKeysAsync(
+	public Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesByKeysAsync(
 		IReadOnlyList<string> issueKeys,
 		IssuesExpandData? expand = null,
 		PaginationSettings? paginationSettings = null,
@@ -208,7 +208,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			Keys = issueKeys
 		};
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
 			"issues/_search",
 			HttpMethod.Post,
 			payload: request,
@@ -218,7 +218,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesByFilterAsync(
+	public Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesByFilterAsync(
 		GetIssuesByFilterRequest request,
 		IssuesExpandData? expand = null,
 		PaginationSettings? paginationSettings = null,
@@ -233,7 +233,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			parameters["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None);
 		}
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
 			"issues/_search",
 			HttpMethod.Post,
 			payload: request,
@@ -243,7 +243,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesByQueryAsync(
+	public Task<YandexTrackerCollectionResponse<GetIssueResponse>> GetIssuesByQueryAsync(
 		string query,
 		IssuesExpandData? expand = null,
 		PaginationSettings? paginationSettings = null,
@@ -263,7 +263,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			Query = query
 		};
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
 			"issues/_search",
 			HttpMethod.Post,
 			payload: request,
@@ -299,11 +299,11 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetComponentResponse>> GetComponentsAsync(
+	public Task<YandexTrackerCollectionResponse<GetComponentResponse>> GetComponentsAsync(
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
 	{
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetComponentResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetComponentResponse>(
 			"components",
 			HttpMethod.Get,
 			payload: null!,
@@ -312,13 +312,13 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<CreateComponentResponse> CreateComponentAsync(
+	public Task<CreateComponentResponse> CreateComponentAsync(
 		CreateComponentRequest request,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(request);
 
-		return await ExecuteYandexTrackerApiRequestAsync<CreateComponentResponse>(
+		return ExecuteYandexTrackerApiRequestAsync<CreateComponentResponse>(
 			"components",
 			HttpMethod.Post,
 			payload: request,
@@ -326,7 +326,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetCommentsResponse>> GetCommentsAsync(
+	public Task<YandexTrackerCollectionResponse<GetCommentsResponse>> GetCommentsAsync(
 		string issueKey,
 		CommentExpandData? expand = null,
 		PaginationSettings? paginationSettings = null,
@@ -341,7 +341,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			parameters["expand"] = expand.Value.ToYandexQueryString(CommentExpandData.All, CommentExpandData.None);
 		}
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetCommentsResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetCommentsResponse>(
 			$"issues/{issueKey}/comments",
 			HttpMethod.Get,
 			parameters: parameters,
@@ -443,10 +443,10 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		string createdBy,
 		CancellationToken cancellationToken = default)
 	{
-		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey, nameof(issueKey));
-		ArgumentNullException.ThrowIfNull(fileStream, nameof(fileStream));
-		ArgumentException.ThrowIfNullOrWhiteSpace(newFileName, nameof(newFileName));
-		ArgumentException.ThrowIfNullOrWhiteSpace(createdBy, nameof(createdBy));
+		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey);
+		ArgumentNullException.ThrowIfNull(fileStream);
+		ArgumentException.ThrowIfNullOrWhiteSpace(newFileName);
+		ArgumentException.ThrowIfNullOrWhiteSpace(createdBy);
 
 		var parameters = new Dictionary<string, string>
 		{
@@ -476,11 +476,11 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		string createdBy,
 		CancellationToken cancellationToken = default)
 	{
-		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey, nameof(issueKey));
-		ArgumentException.ThrowIfNullOrWhiteSpace(commentId, nameof(commentId));
-		ArgumentNullException.ThrowIfNull(fileStream, nameof(fileStream));
-		ArgumentException.ThrowIfNullOrWhiteSpace(newFileName, nameof(newFileName));
-		ArgumentException.ThrowIfNullOrWhiteSpace(createdBy, nameof(createdBy));
+		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey);
+		ArgumentException.ThrowIfNullOrWhiteSpace(commentId);
+		ArgumentNullException.ThrowIfNull(fileStream);
+		ArgumentException.ThrowIfNullOrWhiteSpace(newFileName);
+		ArgumentException.ThrowIfNullOrWhiteSpace(createdBy);
 
 		var parameters = new Dictionary<string, string>
 		{
@@ -521,14 +521,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<string>> GetTagsAsync(
+	public Task<YandexTrackerCollectionResponse<string>> GetTagsAsync(
 		string queueKey,
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(queueKey);
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<string>(
+		return ExecuteYandexTrackerCollectionRequestAsync<string>(
 			$"queues/{queueKey}/tags",
 			HttpMethod.Get,
 			customPaginationSettings: paginationSettings,
@@ -536,7 +536,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<CreateProjectResponse> CreateProjectAsync(
+	public Task<CreateProjectResponse> CreateProjectAsync(
 		ProjectEntityType entityType,
 		CreateProjectRequest request,
 		ProjectFieldData? returnedFields = null,
@@ -552,7 +552,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			parameters["fields"] = returnedFields.Value.ToYandexQueryString(null, ProjectFieldData.None);
 		}
 
-		return await ExecuteYandexTrackerApiRequestAsync<CreateProjectResponse>(
+		return ExecuteYandexTrackerApiRequestAsync<CreateProjectResponse>(
 			$"entities/{entityType.ToCamelCase()}",
 			HttpMethod.Post,
 			payload: request,
@@ -619,14 +619,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetIssueFieldsResponse>> GetLocalQueueFieldsAsync(
+	public Task<YandexTrackerCollectionResponse<GetIssueFieldsResponse>> GetLocalQueueFieldsAsync(
 		string queueKey,
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(queueKey);
 
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetIssueFieldsResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetIssueFieldsResponse>(
 			$"queues/{queueKey}/localFields",
 			HttpMethod.Get,
 			customPaginationSettings: paginationSettings,
@@ -634,11 +634,11 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetIssueFieldsResponse>> GetGlobalFieldsAsync(
+	public Task<YandexTrackerCollectionResponse<GetIssueFieldsResponse>> GetGlobalFieldsAsync(
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
 	{
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetIssueFieldsResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetIssueFieldsResponse>(
 			"fields",
 			HttpMethod.Get,
 			customPaginationSettings: paginationSettings,
@@ -646,9 +646,9 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<UserDetailedInfoDto> GetMyselfAsync(CancellationToken cancellationToken)
+	public Task<UserDetailedInfoDto> GetMyselfAsync(CancellationToken cancellationToken)
 	{
-		return await ExecuteYandexTrackerApiRequestAsync<UserDetailedInfoDto>(
+		return ExecuteYandexTrackerApiRequestAsync<UserDetailedInfoDto>(
 			"myself",
 			HttpMethod.Get,
 			payload: null,
@@ -656,11 +656,11 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<UserDetailedInfoDto> GetUserByIdAsync(
+	public Task<UserDetailedInfoDto> GetUserByIdAsync(
 		string userId,
 		CancellationToken cancellationToken = default)
 	{
-		return await ExecuteYandexTrackerApiRequestAsync<UserDetailedInfoDto>(
+		return ExecuteYandexTrackerApiRequestAsync<UserDetailedInfoDto>(
 			$"users/{userId}",
 			HttpMethod.Get,
 			payload: null,
@@ -668,11 +668,11 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<UserDetailedInfoDto>> GetUsersAsync(
+	public Task<YandexTrackerCollectionResponse<UserDetailedInfoDto>> GetUsersAsync(
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
 	{
-		return await ExecuteYandexTrackerCollectionRequestAsync<UserDetailedInfoDto>(
+		return ExecuteYandexTrackerCollectionRequestAsync<UserDetailedInfoDto>(
 			"users",
 			HttpMethod.Get,
 			customPaginationSettings: paginationSettings,
@@ -716,7 +716,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<CreateQueueLocalFieldResponse> CreateLocalFieldInQueueAsync(
+	public Task<CreateQueueLocalFieldResponse> CreateLocalFieldInQueueAsync(
 		string queueKey,
 		CreateQueueLocalFieldRequest request,
 		CancellationToken cancellationToken = default)
@@ -724,7 +724,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		ArgumentException.ThrowIfNullOrWhiteSpace(queueKey);
 		ArgumentNullException.ThrowIfNull(request);
 
-		return await ExecuteYandexTrackerApiRequestAsync<CreateQueueLocalFieldResponse>(
+		return ExecuteYandexTrackerApiRequestAsync<CreateQueueLocalFieldResponse>(
 			$"queues/{queueKey}/localFields",
 			HttpMethod.Post,
 			payload: request,
@@ -732,11 +732,11 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<YandexTrackerCollectionResponse<GetFieldCategoriesResponse>> GetFieldCategoriesAsync(
+	public Task<YandexTrackerCollectionResponse<GetFieldCategoriesResponse>> GetFieldCategoriesAsync(
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
 	{
-		return await ExecuteYandexTrackerCollectionRequestAsync<GetFieldCategoriesResponse>(
+		return ExecuteYandexTrackerCollectionRequestAsync<GetFieldCategoriesResponse>(
 			"fields/categories",
 			HttpMethod.Get,
 			customPaginationSettings: paginationSettings,
@@ -744,13 +744,13 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task<CreateQueueResponse> CreateQueueAsync(
+	public Task<CreateQueueResponse> CreateQueueAsync(
 		CreateQueueRequest request,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(request);
 
-		return await ExecuteYandexTrackerApiRequestAsync<CreateQueueResponse>(
+		return ExecuteYandexTrackerApiRequestAsync<CreateQueueResponse>(
 			"queues",
 			HttpMethod.Post,
 			payload: request,
@@ -758,11 +758,11 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task DeleteQueueAsync(string queueKey, CancellationToken cancellationToken = default)
+	public Task DeleteQueueAsync(string queueKey, CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(queueKey);
 
-		await ExecuteYandexTrackerApiRequestAsync(
+		return ExecuteYandexTrackerApiRequestAsync(
 			$"queues/{queueKey}",
 			HttpMethod.Delete,
 			payload: null,
@@ -770,14 +770,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task DeleteCommentAsync(
+	public Task DeleteCommentAsync(
 		string issueKey,
 		int commentId,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey);
 
-		await ExecuteYandexTrackerApiRequestAsync(
+		return ExecuteYandexTrackerApiRequestAsync(
 			$"issues/{issueKey}/comments/{commentId}",
 			HttpMethod.Delete,
 			payload: null,
@@ -785,12 +785,12 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task DeleteAttachmentAsync(string issueKey, string attachmentKey, CancellationToken cancellationToken = default)
+	public Task DeleteAttachmentAsync(string issueKey, string attachmentKey, CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey);
 		ArgumentException.ThrowIfNullOrWhiteSpace(attachmentKey);
 
-		await ExecuteYandexTrackerApiRequestAsync(
+		return ExecuteYandexTrackerApiRequestAsync(
 			$"issues/{issueKey}/attachments/{attachmentKey}",
 			HttpMethod.Delete,
 			payload: null,
@@ -798,7 +798,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	}
 
 	/// <inheritdoc />
-	public async Task DeleteProjectAsync(
+	public Task DeleteProjectAsync(
 		ProjectEntityType entityType,
 		int projectShortId,
 		bool? deleteWithBoard = null,
@@ -809,7 +809,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		if (deleteWithBoard is not null)
 			parameters["withBoard"] = deleteWithBoard.ToString()!;
 
-		await ExecuteYandexTrackerApiRequestAsync(
+		return ExecuteYandexTrackerApiRequestAsync(
 			$"entities/{entityType.ToCamelCase()}/{projectShortId}",
 			HttpMethod.Delete,
 			payload: null,

--- a/Mindbox.YandexTracker/YandexTrackerClient.cs
+++ b/Mindbox.YandexTracker/YandexTrackerClient.cs
@@ -98,11 +98,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(queueKey);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null and not QueueExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(QueueExpandData.All, QueueExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(QueueExpandData.All, QueueExpandData.None)
+			};
 		}
 
 		return ExecuteYandexTrackerApiRequestAsync<GetQueuesResponse>(
@@ -119,11 +122,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		PaginationSettings? paginationSettings = null,
 		CancellationToken cancellationToken = default)
 	{
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null && (QueuesExpandData)expand != QueuesExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(null, QueuesExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(null, QueuesExpandData.None)
+			};
 		}
 
 		return ExecuteYandexTrackerCollectionRequestAsync<GetQueuesResponse>(
@@ -142,11 +148,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null and not IssueExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(null, IssueExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(null, IssueExpandData.None)
+			};
 		}
 
 		return ExecuteYandexTrackerApiRequestAsync<GetIssueResponse>(
@@ -166,11 +175,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(queueKey);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null and not IssuesExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None)
+			};
 		}
 
 		var request = new GetIssuesFromQueueRequest
@@ -196,11 +208,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentNullException.ThrowIfNull(issueKeys);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null and not IssuesExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None)
+			};
 		}
 
 		var request = new GetIssuesFromKeysRequest
@@ -226,11 +241,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentNullException.ThrowIfNull(request);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null and not IssuesExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None)
+			};
 		}
 
 		return ExecuteYandexTrackerCollectionRequestAsync<GetIssueResponse>(
@@ -251,11 +269,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(query);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null and not IssuesExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(null, IssuesExpandData.None)
+			};
 		}
 
 		var request = new GetIssuesByQueryRequest
@@ -292,7 +313,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		ArgumentNullException.ThrowIfNull(request);
 
 		return ExecuteYandexTrackerApiRequestAsync<ImportIssueResponse>(
-			"issues/_import ",
+			"issues/_import",
 			HttpMethod.Post,
 			payload: request,
 			cancellationToken: cancellationToken);
@@ -334,11 +355,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (expand is not null and not CommentExpandData.None)
 		{
-			parameters["expand"] = expand.Value.ToYandexQueryString(CommentExpandData.All, CommentExpandData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["expand"] = expand.Value.ToYandexQueryString(CommentExpandData.All, CommentExpandData.None)
+			};
 		}
 
 		return ExecuteYandexTrackerCollectionRequestAsync<GetCommentsResponse>(
@@ -418,10 +442,15 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		ArgumentException.ThrowIfNullOrWhiteSpace(issueKey);
 		ArgumentNullException.ThrowIfNull(fileStream);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (newFileName is not null)
-			parameters["filename"] = newFileName;
+		{
+			parameters = new Dictionary<string, string>
+			{
+				["filename"] = newFileName
+			};
+		}
 
 		using var form = new MultipartFormDataContent();
 		using var fileContent = new StreamContent(fileStream);
@@ -544,12 +573,14 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 	{
 		ArgumentNullException.ThrowIfNull(request);
 
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
-		if (returnedFields is not null
-			and not ProjectFieldData.None)
+		if (returnedFields is not null and not ProjectFieldData.None)
 		{
-			parameters["fields"] = returnedFields.Value.ToYandexQueryString(null, ProjectFieldData.None);
+			parameters = new Dictionary<string, string>
+			{
+				["fields"] = returnedFields.Value.ToYandexQueryString(null, ProjectFieldData.None)
+			};
 		}
 
 		return ExecuteYandexTrackerApiRequestAsync<CreateProjectResponse>(
@@ -804,10 +835,15 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 		bool? deleteWithBoard = null,
 		CancellationToken cancellationToken = default)
 	{
-		var parameters = new Dictionary<string, string>();
+		Dictionary<string, string>? parameters = null;
 
 		if (deleteWithBoard is not null)
-			parameters["withBoard"] = deleteWithBoard.ToString()!;
+		{
+			parameters = new Dictionary<string, string>
+			{
+				["withBoard"] = deleteWithBoard.ToString()!
+			};
+		}
 
 		return ExecuteYandexTrackerApiRequestAsync(
 			$"entities/{entityType.ToCamelCase()}/{projectShortId}",

--- a/Mindbox.YandexTracker/YandexTrackerClient.cs
+++ b/Mindbox.YandexTracker/YandexTrackerClient.cs
@@ -641,7 +641,7 @@ public sealed class YandexTrackerClient : IYandexTrackerClient
 			response.Pages > page
 			&& (pagination.MaxPageRequestCount is null || page < pagination.MaxPageRequestCount));
 
-		return new YandexTrackerCollectionResponse<ProjectInfo>()
+		return new YandexTrackerCollectionResponse<ProjectInfo>
 		{
 			FetchedPages = page,
 			TotalPages = response.Pages,

--- a/Mindbox.YandexTracker/YandexTrackerConstants.cs
+++ b/Mindbox.YandexTracker/YandexTrackerConstants.cs
@@ -1,0 +1,9 @@
+namespace Mindbox.YandexTracker;
+
+public static class YandexTrackerConstants
+{
+	/// <summary>
+	/// Формат даты и времени, который принимает API Яндекс.Трекера.
+	/// </summary>
+	public static readonly string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffzzz";
+}

--- a/Mindbox.YandexTracker/YandexTrackerConstants.cs
+++ b/Mindbox.YandexTracker/YandexTrackerConstants.cs
@@ -1,3 +1,17 @@
+// Copyright 2024 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Mindbox.YandexTracker;
 
 public static class YandexTrackerConstants


### PR DESCRIPTION
## Что сделано

- Добавлены методы для импорта задач, комментариев и вложений
- Поправил название статусов проектов
- Добавил пропущенные поля в issue/project

## Дополнительно

- Тесты лучше подчищают со собой после работы
- Добавил политику retry в тесты при обращении к API, чтобы тесты работали более стабильно
- Местами у DTO убраны `sealed`, чтобы можно было расширять классы
- Немного добавил комментов
- Поменял порядок полей в классе, чтобы близкие по смыслы поля располагались рядом 